### PR TITLE
Update .asf.yaml to activate Github issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,2 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+---
 publish:
   whoami: asf-site
+  
+github:  
+  features:
+    # Enable issues management
+    issues: true
+    # Enable wiki for documentation
+    wiki: false
+    # Enable projects for project management boards
+    projects: true


### PR DESCRIPTION
Added licence header and feature details to activate github issues for kibble website repository.