### PR TITLE
Minor updates to Kibble website

### DIFF
--- a/source/markdown/docs/documentation.md
+++ b/source/markdown/docs/documentation.md
@@ -4,3 +4,4 @@
 Please see our documentation at [Read the Docs](https://apache-kibble.readthedocs.io/)
 for details on operating and using Kibble.
 
+**IMPORTANT NOTE:** Please note that the documentation currently refers to the code for [Kibble-1](https://github.com/apache/kibble-1) and the [Kibble-Scanners](https://github.com/apache/kibble-scanners) Github repositories.

--- a/source/template.html
+++ b/source/template.html
@@ -31,7 +31,7 @@
     %CONTENT%
   </div>
   <footer>
-    Copyright 2022, the Apache Software Foundation. Licensed under the <a href="https://www.apache.org/licenses/">Apache License v/2</a>.<br/>
+    Copyright 2024, the Apache Software Foundation. Licensed under the <a href="https://www.apache.org/licenses/">Apache License v/2</a>.<br/>
     <i style="font-size: 75%">
     Apache Kibble, Kibble, Apache, the Apache feather logo, and the Apache Kibble project logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and other countries.
     </i><br/>


### PR DESCRIPTION
Minor updates to website including noting that documentation refers to Kibble-1 and Kibble-Scanners